### PR TITLE
bugfix acp: prevent select to be not defined

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -170,6 +170,10 @@ class main_module
 				$actions = '30d';
 			}
 			$sort_by = $request->variable('sort_by', 'reg_date');
+			if ($sort_by == 'select')
+			{
+				$sort_by = 'reg_date';
+			}
 			$sort_order = $request->variable('sort_order', 0);
 
 			// Keep the limit between 20 and 200


### PR DESCRIPTION
in ACP inactive userlist, the dropdown for "sort_by" has no prevention to select the "select" itself.